### PR TITLE
ProximityOnWakePreferenceController: fix crash in settings-search due…

### DIFF
--- a/src/com/android/settings/display/ProximityOnWakePreferenceController.java
+++ b/src/com/android/settings/display/ProximityOnWakePreferenceController.java
@@ -20,10 +20,11 @@ import android.support.v7.preference.Preference;
 
 import com.gzr.wolvesden.preference.SystemSettingSwitchPreference;
 
+import com.android.settings.core.PreferenceControllerMixin;
 import com.android.settings.core.PreferenceController;
 
 public class ProximityOnWakePreferenceController extends PreferenceController implements
-        Preference.OnPreferenceChangeListener {
+        PreferenceControllerMixin, Preference.OnPreferenceChangeListener {
 
     private static final String KEY_PROXIMITY_WAKE = "proximity_on_wake";
 


### PR DESCRIPTION
… to missing implementation of "PreferenceControllerMixin".

Tapping on the search-box in the settings crashes.
Relevant part of logcat:
`05-05 13:13:32.727  8785  8825 E AndroidRuntime: Caused by: java.lang.IllegalStateException: com.android.settings.display.ProximityOnWakePreferenceController must implement com.android.settings.core.PreferenceControllerMixin`

This pull-request fixes it.